### PR TITLE
Add watch function to guide, in alignment with updated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,18 +282,39 @@ and add the following code to it:
 const esbuild = require('esbuild');
 const ElmPlugin = require('esbuild-plugin-elm');
 
-esbuild.build({
-  entryPoints: ['src/index.js'],
-  bundle: true,
-  outdir: '../js',
-  watch: process.argv.includes('--watch'),
-  plugins: [
-    ElmPlugin({
-      debug: true,
-      clearOnWatch: true,
-    }),
-  ],
-}).catch(_e => process.exit(1))
+const isProduction = process.env.MIX_ENV === "prod"
+
+async function watch() {
+  const ctx = await esbuild.context({
+    entryPoints: ['src/index.js'],
+    bundle: true,
+    outfile: '../js/elm.js',
+    plugins: [
+      ElmPlugin({
+        debug: true
+      }),
+    ],
+  }).catch(_e => process.exit(1))
+  await ctx.watch()
+}
+
+
+async function build() {
+  await esbuild.build({
+    entryPoints: ['src/index.js'],
+    bundle: true,
+    minify: true,
+    outfile: '../js/elm.js',
+    plugins: [
+      ElmPlugin(),
+    ],
+  }).catch(_e => process.exit(1))
+}
+
+if (isProduction)
+  build()
+else
+  watch()
 ```
 
 Ref: 


### PR DESCRIPTION
The code in assets/elm/build.js works, but the sample code in the guide doesn't.  For those who are copy-pasting, this change makes their code work properly by aligning the guide with the actual code.